### PR TITLE
updating some deprecated infos

### DIFF
--- a/en/docs/5.4-audience-integration.md
+++ b/en/docs/5.4-audience-integration.md
@@ -5,11 +5,11 @@
 Audience integration can be done in two ways:
 
 1.  **Real-Time Segmentation:** Sending audience data directly in the ad request.
-2.  **Batch Submission:** Sending files with audience data to an S3 bucket.
+2.  **Batch Submission:** Sending files with audience data to an FTP server.
 
 ### Batch Submission
 
-The integration connection will occur through the periodic sending of audiences to our S3. Access credentials must be requested from your Newtail contact.
+The integration connection will occur through the periodic sending of audiences to our FTP server. Access credentials must be requested from your Newtail contact.
 
 *   **File Format:** `Parquet` with `Snappy` compression.
 *   **Directory Pattern:** Files must be written in the following directory pattern:

--- a/en/docs/7-script-agent.md
+++ b/en/docs/7-script-agent.md
@@ -23,7 +23,7 @@ The VTEX Ads script was developed to exclusively collect non-sensitive browsing 
 
 The script should be loaded asynchronously so as not to impact the page load time.
 
--   **Script URL:** `https://cdn.newtail.com.br/retail-media/scripts/vtexads-agent.1.0.0.js`
+-   **Script URL:** `https://cdn.newtail.com.br/retail-media/scripts/vtexrma-agent.1.0.0.js`
 
 ## 7.4. Step-by-Step Guide for Implementation via Google Tag Manager (GTM)
 
@@ -37,7 +37,7 @@ To ensure the script runs as early as possible during page load, we recommend us
 4.  Click on **"Tag Configuration"** and select the **"Custom HTML"** tag type.
 5.  In the HTML field, insert the following code:
     ```html
-    <script type="text/javascript" async src="https://cdn.newtail.com.br/retail-media/scripts/vtexads-agent.1.0.0.js"></script>
+    <script type="text/javascript" async src="https://cdn.newtail.com.br/retail-media/scripts/vtexrma-agent.1.0.0.js"></script>
     ```
 
 ### Step 7.4.2: Configure the Main Trigger

--- a/es/docs/5.4-integracion-de-audiencias.md
+++ b/es/docs/5.4-integracion-de-audiencias.md
@@ -5,11 +5,11 @@
 La integración de audiencias se puede realizar de dos maneras:
 
 1.  **Segmentación en Tiempo Real:** Enviando los datos de la audiencia directamente en la solicitud de anuncios.
-2.  **Envío por Lotes (Batch):** Enviando archivos con los datos de la audiencia a un S3.
+2.  **Envío por Lotes (Batch):** Enviando archivos con los datos de la audiencia a un servidor FTP.
 
 ### Envio por Lotes (Batch)
 
-La conexión de integración se realizará mediante el envío periódico de las audiencias a nuestro S3. Las credenciales de acceso deben ser solicitadas a su contacto en Newtail.
+La conexión de integración se realizará mediante el envío periódico de las audiencias a nuestro servidor FTP. Las credenciales de acceso deben ser solicitadas a su contacto en Newtail.
 
 *   **Formato de Archivo:** `Parquet` con compresión `Snappy`.
 *   **Patrón de Directorio:** Los archivos deben ser escritos en el siguiente patrón de directorio:

--- a/es/docs/5.5-consulta-de-anuncios.md
+++ b/es/docs/5.5-consulta-de-anuncios.md
@@ -33,7 +33,7 @@ Con el catálogo sincronizado, su plataforma solicita anuncios para completar lo
 | `tags` | "Etiquetas" para contextualizar búsquedas. Máx. 10 por SKU, 64 caracteres por tag. Solo para campañas de `product`. | Array[String] | No |
 | `brand` | Nombre del sitio del publisher. | String | Obligatorio cuando el publisher tiene múltiples sitios |
 | `dedup_campaign_ads` | Define si los resultados deben ser deduplicados por campaña. Es decir, la respuesta contendrá como máximo un anuncio por campaña. | Boolean | No (Default=false) |
-| `dedup_ads` | Define si los resultados deben ser deduplicados los anuncios en múltiples placements (usar solo cuando se consultan múltiples placements al mismo tiempo). | Boolean | No (Default=false) |
+| `dedup_ads` | Define si los resultados deben ser deduplicados por anuncio en múltiples placements (usar solo cuando se consultan múltiples placements al mismo tiempo). | Boolean | No (Default=false) |
 
 #### **Respuesta de la Consulta**
 La respuesta es un JSON donde cada clave es un nombre de `placement`. La estructura de cada anuncio en la respuesta depende de su tipo.

--- a/es/docs/7-script-agent.md
+++ b/es/docs/7-script-agent.md
@@ -23,7 +23,7 @@ El script de VTEX Ads fue desarrollado para recopilar exclusivamente datos de na
 
 El script debe cargarse de forma asíncrona para no afectar el tiempo de carga de la página.
 
--   **URL del Script:** `https://cdn.newtail.com.br/retail-media/scripts/vtexads-agent.1.0.0.js`
+-   **URL del Script:** `https://cdn.newtail.com.br/retail-media/scripts/vtexrma-agent.1.0.0.js`
 
 ## 7.4. Paso a Paso para la Implementación a través de Google Tag Manager (GTM)
 
@@ -37,7 +37,7 @@ Para garantizar que el script se ejecute lo antes posible en la carga de la pág
 4.  Haga clic en **"Configuración de la etiqueta"** y seleccione el tipo de etiqueta **"HTML personalizado"**.
 5.  En el campo de HTML, inserte el siguiente código:
     ```html
-    <script type="text/javascript" async src="https://cdn.newtail.com.br/retail-media/scripts/vtexads-agent.1.0.0.js"></script>
+    <script type="text/javascript" async src="https://cdn.newtail.com.br/retail-media/scripts/vtexrma-agent.1.0.0.js"></script>
     ```
 
 ### Paso 7.4.2: Configurar el Activador Principal

--- a/pt/docs/5.4-integracao-de-audiencias.md
+++ b/pt/docs/5.4-integracao-de-audiencias.md
@@ -5,11 +5,11 @@
 A integração de audiências pode ser feita de duas maneiras:
 
 1.  **Segmentação em Tempo Real:** Enviando os dados de audiência diretamente na requisição de anúncios.
-2.  **Envio em Lote (Batch):** Enviando arquivos com os dados de audiência para um S3.
+2.  **Envio em Lote (Batch):** Enviando arquivos com os dados de audiência para um servidor FTP.
 
 ### Envio em Lote (Batch)
 
-A conexão de integração ocorrerá através do envio periódico das audiências para o nosso S3. As credenciais de acesso devem ser solicitadas ao seu contato na Newtail.
+A conexão de integração ocorrerá através do envio periódico das audiências para o nosso servidor FTP. As credenciais de acesso devem ser solicitadas ao seu contato na Newtail.
 
 *   **Formato do Arquivo:** `Parquet` com compressão `Snappy`.
 *   **Padrão de Diretório:** Os arquivos devem ser escritos no seguinte padrão de diretório:

--- a/pt/docs/5.5-consulta-de-anuncios.md
+++ b/pt/docs/5.5-consulta-de-anuncios.md
@@ -33,7 +33,7 @@ Com o catálogo sincronizado, sua plataforma requisita anúncios para preencher 
 | `tags` | "Etiquetas" para contextualizar buscas. Máx. 10 por SKU, 64 chars por tag. Apenas para campanhas de `product`. | Array[String] | Não |
 | `brand` | Nome do site do publisher. | String | Obrigatório quando o publisher possui mais de um site |
 | `dedup_campaign_ads` | Define se os resultados devem ser deduplicados por campanha. Ou seja, a resposta conterá no máximo um anúncio por campanha. | Boolean | Não (Default=false) |
-| `dedup_ads` | Define se os resultados devem ser deduplicados os ads em multiplos placements (usar apenas quando consultar multiplos placements ao menos tempo). | Boolean | Não (Default=false) |
+| `dedup_ads` | Define se os resultados devem ser deduplicados por ads em multiplos placements (usar apenas quando consultar multiplos placements ao menos tempo). | Boolean | Não (Default=false) |
 
 #### **Resposta da Consulta**
 A resposta é um JSON onde cada chave é um nome de `placement`. A estrutura de cada anúncio na resposta depende do seu tipo.

--- a/pt/docs/7-script-agent.md
+++ b/pt/docs/7-script-agent.md
@@ -29,7 +29,7 @@ O script da VTEX Ads foi desenvolvido para coletar exclusivamente dados de naveg
 
 O script deve ser carregado de forma assíncrona para não impactar o tempo de carregamento da página.
 
--   **URL do Script:** `https://cdn.newtail.com.br/retail-media/scripts/vtexads-agent.1.0.0.js`
+-   **URL do Script:** `https://cdn.newtail.com.br/retail-media/scripts/vtexrma-agent.1.0.0.js`
 
 
 ## 7.4. Passo a Passo para Implementação via Google Tag Manager (GTM)
@@ -49,7 +49,7 @@ Para garantir que o script seja executado o mais cedo possível no carregamento 
 5.  No campo de HTML, insira o seguinte código:
 
     ```
-    <script type="text/javascript" async src="https://cdn.newtail.com.br/retail-media/scripts/vtexads-agent.1.0.0.js"></script>
+    <script type="text/javascript" async src="https://cdn.newtail.com.br/retail-media/scripts/vtexrma-agent.1.0.0.js"></script>
     ```
 
 


### PR DESCRIPTION
- Changing offsite script url to `https://cdn.newtail.com.br/retail-media/scripts/vtexrma-agent.1.0.0.js` (avoiding adblock)
- Audiences file should be sent to FTP and not to S3
- Fix typos on `dedup_ads`