### PR TITLE
docs: add guidance for 18+ campaign eligibility

### DIFF
--- a/en/docs/5.4-audience-integration.md
+++ b/en/docs/5.4-audience-integration.md
@@ -32,6 +32,8 @@ The integration connection occurs through periodic audience uploads to the publi
 
 If you choose not to integrate audiences via batch, you can still use segmentation at runtime by sending the data in the `segmentation` field of the ad query request. See [5.5. Ad Query](5.5-ad-query.md).
 
+> **Important for `18+` campaigns:** Campaigns marked as `18+` depend on sending the user's age in the ad query request itself, using `segmentation` with the `AGE` key. If age is not informed, the request will be treated as coming from an underage user and `18+` campaigns will not be returned.
+
 ### Audience File Attributes
 
 Most attributes are not mandatory, however, the more complete this information is, the better the relevance will be.

--- a/en/docs/5.5-ad-query.md
+++ b/en/docs/5.5-ad-query.md
@@ -340,7 +340,7 @@ Target ads to specific audiences to increase relevance.
 Send demographic or audience data directly in the body of the **ad query**, in the `segmentation` field.
 
 The `segmentation` field is an array of objects, where each object contains:
-- `key`: The type of segmentation (e.g., "STATE", "CITY", "GENDER")
+- `key`: The type of segmentation (e.g., "STATE", "CITY", "GENDER", "AGE")
 - `values`: Array of values for the segmentation
 
 **Segmentation Example:**
@@ -372,6 +372,43 @@ The `segmentation` field is an array of objects, where each object contains:
 | `AGE` | User's age | "22", "35" |
 | `AUDIENCES` | Custom audience | "high_value_customers", "cart_abandoners" |
 | `NBO_CATEGORIES` | Indicates the possible categories that the user intends to buy | "Electronics", "Books" |
+
+#### **`18+` Campaigns**
+
+During campaign creation, the advertiser can mark the campaign as intended for people aged `18` or older. From that point on, the campaign is only eligible for requests that inform the user's age in `segmentation`, using the `AGE` key.
+
+**Request example with age targeting:**
+
+```json
+{
+  "session_id": "f361661f-5986-4779-9009-a34562f18347",
+  "channel": "site",
+  "context": "home",
+  "placements": {
+    "site_home_top_banner": {
+      "quantity": 1,
+      "types": ["banner"]
+    }
+  },
+  "segmentation": [
+    {
+      "key": "AGE",
+      "values": ["18"]
+    }
+  ]
+}
+```
+
+**Expected behavior:**
+
+- `AGE >= 18`: `18+` campaigns may be returned, as long as the campaign's other criteria are also met.
+- `AGE < 18`: `18+` campaigns are never returned.
+- No `AGE` in the request: the user is always treated as underage, and `18+` campaigns are never returned.
+
+**Network behavior:**
+
+- For campaigns linked to multiple publishers in VTEX Ads Network, the `18+` campaign will only appear for publishers that implement and send age targeting in the ad query.
+- Publishers that do not send `AGE` in the request will not receive `18+` campaigns.
 
 ### Response Codes and Errors
 

--- a/es/docs/5.4-integracion-de-audiencias.md
+++ b/es/docs/5.4-integracion-de-audiencias.md
@@ -32,6 +32,8 @@ La conexión de integración se realiza mediante el envío periódico de audienc
 
 Si decide no integrar audiencias vía batch, todavía puede usar segmentaciones en runtime enviando los datos en el campo `segmentation` de la solicitud de consulta de anuncios. Consulte la sección [5.5. Consulta de Anuncios](5.5-consulta-de-anuncios.md).
 
+> **Importante para campañas `18+`:** Las campañas marcadas como `18+` dependen del envío de la edad del usuario en la propia solicitud de consulta de anuncios, usando `segmentation` con la clave `AGE`. Si la edad no es informada, la solicitud será tratada como correspondiente a un usuario menor de edad y las campañas `18+` no serán retornadas.
+
 ### Atributos del Archivo de Audiencias
 
 La mayoría de los atributos no son obligatorios, sin embargo, cuanto mayor sea el llenado de toda esta información, mejor será la relevancia.

--- a/es/docs/5.5-consulta-de-anuncios.md
+++ b/es/docs/5.5-consulta-de-anuncios.md
@@ -339,7 +339,7 @@ Dirija anuncios a públicos específicos para aumentar la relevancia.
 Envíe datos demográficos o de audiencia directamente en el cuerpo de la **consulta de anuncios**, en el campo `segmentation`.
 
 El campo `segmentation` es un array de objetos, donde cada objeto contiene:
-- `key`: El tipo de segmentación (ej: "STATE", "CITY", "GENDER")
+- `key`: El tipo de segmentación (ej: "STATE", "CITY", "GENDER", "AGE")
 - `values`: Array de valores para la segmentación
 
 **Ejemplo de Segmentación:**
@@ -371,6 +371,43 @@ El campo `segmentation` es un array de objetos, donde cada objeto contiene:
 | `AGE` | Edad del usuario | "22", "35" |
 | `AUDIENCES` | Audiencia personalizada | "clientes_alto_valor", "abandonadores_carrito" |
 | `NBO_CATEGORIES` | Indica las posibles categorías que el usuario tiene intención de comprar | "Electrónica", "Libros" |
+
+#### **Campañas `18+`**
+
+Durante la creación de la campaña, el anunciante puede marcarla como destinada a personas de `18` años o más. A partir de ese momento, la campaña solo será elegible para solicitudes que informen la edad del usuario en `segmentation`, usando la clave `AGE`.
+
+**Ejemplo de solicitud con segmentación por edad:**
+
+```json
+{
+  "session_id": "f361661f-5986-4779-9009-a34562f18347",
+  "channel": "site",
+  "context": "home",
+  "placements": {
+    "site_home_top_banner": {
+      "quantity": 1,
+      "types": ["banner"]
+    }
+  },
+  "segmentation": [
+    {
+      "key": "AGE",
+      "values": ["18"]
+    }
+  ]
+}
+```
+
+**Comportamiento esperado:**
+
+- `AGE >= 18`: las campañas `18+` pueden ser retornadas, siempre que también se cumplan los demás criterios de la campaña.
+- `AGE < 18`: las campañas `18+` nunca son retornadas.
+- Sin `AGE` en la solicitud: el usuario siempre es tratado como menor de edad, y las campañas `18+` nunca son retornadas.
+
+**Comportamiento en Network:**
+
+- En campañas vinculadas a múltiples publishers en VTEX Ads Network, la campaña `18+` solo aparecerá para publishers que implementen y envíen la segmentación por edad en la consulta del anuncio.
+- Los publishers que no envíen `AGE` en la solicitud no recibirán campañas `18+`.
 
 ### Códigos de Respuesta y Errores
 

--- a/pt/docs/5.4-integracao-de-audiencias.md
+++ b/pt/docs/5.4-integracao-de-audiencias.md
@@ -32,6 +32,8 @@ A conexão de integração ocorre através do envio periódico das audiências p
 
 Se você optar por não integrar audiências via batch, ainda é possível utilizar segmentações em runtime enviando os dados no campo `segmentation` da requisição de consulta de anúncios. Consulte a seção [5.5. Consulta de Anúncios](5.5-consulta-de-anuncios.md).
 
+> **Importante para campanhas `18+`:** Campanhas marcadas como `18+` dependem do envio da idade do usuário na própria requisição de consulta de anúncios, usando `segmentation` com a chave `AGE`. Se a idade não for informada, a requisição será tratada como de usuário menor de idade e campanhas `18+` não serão retornadas.
+
 ### Atributos do Arquivo de Audiências
 
 A maioria dos atributos não são obrigatórios, no entanto, quanto maior for o preenchimento de todas essas informações, a relevância será melhor.

--- a/pt/docs/5.5-consulta-de-anuncios.md
+++ b/pt/docs/5.5-consulta-de-anuncios.md
@@ -340,7 +340,7 @@ Direcione anúncios para públicos específicos para aumentar a relevância.
 Envie dados demográficos ou de audiência diretamente no corpo da **consulta de anúncios**, no campo `segmentation`.
 
 O campo `segmentation` é um array de objetos, onde cada objeto contém:
-- `key`: O tipo de segmentação (ex: "STATE", "CITY", "GENDER")
+- `key`: O tipo de segmentação (ex: "STATE", "CITY", "GENDER", "AGE")
 - `values`: Array de valores para a segmentação
 
 **Exemplo de Segmentação:**
@@ -372,6 +372,43 @@ O campo `segmentation` é um array de objetos, onde cada objeto contém:
 | `AGE` | Idade do usuário | "22", "35" |
 | `AUDIENCES` | Audiência personalizada | "high_value_customers", "cart_abandoners" |
 | `NBO_CATEGORIES` | Indica quais as possíveis categorias que o usuário tem intenção de comprar | "Eletrônicos", "Livros" |
+
+#### **Campanhas `18+`**
+
+Durante a criação da campanha, o anunciante pode marcá-la como destinada a pessoas com `18` anos ou mais. A partir desse momento, a campanha só será elegível para requisições que informem a idade do usuário em `segmentation`, usando a chave `AGE`.
+
+**Exemplo de requisição com segmentação por idade:**
+
+```json
+{
+  "session_id": "f361661f-5986-4779-9009-a34562f18347",
+  "channel": "site",
+  "context": "home",
+  "placements": {
+    "site_home_top_banner": {
+      "quantity": 1,
+      "types": ["banner"]
+    }
+  },
+  "segmentation": [
+    {
+      "key": "AGE",
+      "values": ["18"]
+    }
+  ]
+}
+```
+
+**Comportamento esperado:**
+
+- `AGE >= 18`: campanhas `18+` podem ser retornadas, desde que os demais critérios da campanha também sejam atendidos.
+- `AGE < 18`: campanhas `18+` nunca são retornadas.
+- Sem `AGE` na requisição: o usuário é sempre tratado como menor de idade, e campanhas `18+` nunca são retornadas.
+
+**Comportamento em Network:**
+
+- Em campanhas vinculadas a múltiplos publishers na VTEX Ads Network, a campanha `18+` só aparecerá para publishers que implementam e enviam a segmentação por idade na consulta do anúncio.
+- Publishers que não enviam `AGE` na requisição não receberão campanhas `18+`.
 
 ### Códigos de Resposta e Erros
 


### PR DESCRIPTION
## Summary
- document 18+ campaign eligibility in PT, EN, and ES
- clarify that `AGE` must be sent in `segmentation` for 18+ campaigns to be eligible
- document that requests without `AGE` are treated as underage and that Network delivery depends on publisher age segmentation

## Validation
- `git diff --check`