### PR TITLE
docs: add advertiser campaigns detailed export

### DIFF
--- a/en/docs/6-data-export.md
+++ b/en/docs/6-data-export.md
@@ -8,10 +8,10 @@ In addition to exporting via S3, it is possible to extract reports via the API. 
 
 *  `GET /report/v2/advertisers`: Advertiser information (publisher view) [[Example]](../../examples/EXPORT_ADVERTISER_DATA.md)
 *  `GET /report/v2/publishers`: Publisher information (advertiser view) [[Example]](../../examples/EXPORT_PUBLISHER_DATA.md)
-*  `GET /report/network/publishers`: Network publishers (for Network type accounts) [[Example]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
+*  `GET /report/network/publishers`: Network publishers (for Network type accounts) [[Example]](../../examples/EXPORT_NETWORK_PUBLISHERS_DATA.md)
 *  `GET /campaign/v2`: Campaign listing report [[Example]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Detailed campaign report [[Example]](../../examples/EXPORT_CAMPAIGN_DATA.md)
-*  `GET /report/advertisers/campaigns-detailed`: Detailed mixed campaign report for advertiser accounts, including subpublisher rows for network campaigns [[Example]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
+*  `GET /report/advertisers/campaigns-detailed`: Detailed mixed campaign report for advertiser accounts, including subpublisher information for network campaigns [[Example]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Performance report for individual ads  [[Example]](../../examples/EXPORT_ADS_DATA.md)
 
 ### 6.2. Data Export

--- a/en/docs/6-data-export.md
+++ b/en/docs/6-data-export.md
@@ -11,6 +11,7 @@ In addition to exporting via S3, it is possible to extract reports via the API. 
 *  `GET /report/network/publishers`: Network publishers (for Network type accounts) [[Example]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/v2`: Campaign listing report [[Example]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Detailed campaign report [[Example]](../../examples/EXPORT_CAMPAIGN_DATA.md)
+*  `GET /report/advertisers/campaigns-detailed`: Detailed mixed campaign report for advertiser accounts, including subpublisher rows for network campaigns [[Example]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Performance report for individual ads  [[Example]](../../examples/EXPORT_ADS_DATA.md)
 
 ### 6.2. Data Export

--- a/es/docs/6-exportacion-de-datos.md
+++ b/es/docs/6-exportacion-de-datos.md
@@ -2,19 +2,19 @@
 
 La exportación de datos le permite recibir información detallada sobre eventos y datos agregados de forma sistemática y periódica. La integración se realiza a través de una conexión S3, y los datos se entregan en formatos específicos para cada tipo de exportación.
 
-### 5.1. Reportes
+### 6.1. Reportes
 
 Además de la exportación a través de S3, es posible extraer informes a través de la API. Las rutas devuelven JSON por defecto, pero se pueden exportar como archivos XLSX incluyendo el parámetro `download=true` en la consulta.
 
 *  `GET /report/v2/advertisers`: Información de anunciantes (vista del publisher) [[Ejemplo]](../../examples/EXPORT_ADVERTISER_DATA.md)
 *  `GET /report/v2/publishers`: Información del publisher (vista del anunciante) [[Ejemplo]](../../examples/EXPORT_PUBLISHER_DATA.md)
 *  `GET /report/network/publishers`: Publishers de la red (para cuentas de tipo Red) [[Ejemplo]](../../examples/EXPORT_NETWORK_PUBLISHERS_DATA.md)
-*  `GET /campaign/v2`: Informe listado de campañas [[Ejemplo]](../../examples/EXPORT_NETWORK_PUBLISHERS_DATA.md)
+*  `GET /campaign/v2`: Informe listado de campañas [[Ejemplo]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Informe detallado de la campaña [[Ejemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
-*  `GET /report/advertisers/campaigns-detailed`: Informe detallado de campañas mixtas para cuentas de anunciante, incluyendo filas por subpublisher en campañas de red [[Ejemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
-*  `GET /ad/results/v2`: Informe de anuncios individuales [[Ejemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
+*  `GET /report/advertisers/campaigns-detailed`: Informe detallado de campañas mixtas para cuentas de anunciante, incluyendo información de subpublisher en campañas de red [[Ejemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
+*  `GET /ad/results/v2`: Informe de anuncios individuales [[Ejemplo]](../../examples/EXPORT_ADS_DATA.md)
 
-### 5.2. Exportación de Datos
+### 6.2. Exportación de Datos
 
 La integración siempre se realizará mediante una conexión S3 (o compatible) que deberá ser proporcionada por el receptor de los datos. Las credenciales deben ser entregadas al equipo de Newtail de forma segura.
 

--- a/es/docs/6-exportacion-de-datos.md
+++ b/es/docs/6-exportacion-de-datos.md
@@ -11,6 +11,7 @@ Además de la exportación a través de S3, es posible extraer informes a travé
 *  `GET /report/network/publishers`: Publishers de la red (para cuentas de tipo Red) [[Ejemplo]](../../examples/EXPORT_NETWORK_PUBLISHERS_DATA.md)
 *  `GET /campaign/v2`: Informe listado de campañas [[Ejemplo]](../../examples/EXPORT_NETWORK_PUBLISHERS_DATA.md)
 *  `GET /campaign/:id`: Informe detallado de la campaña [[Ejemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
+*  `GET /report/advertisers/campaigns-detailed`: Informe detallado de campañas mixtas para cuentas de anunciante, incluyendo filas por subpublisher en campañas de red [[Ejemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Informe de anuncios individuales [[Ejemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
 
 ### 5.2. Exportación de Datos

--- a/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
@@ -6,7 +6,8 @@ This endpoint allows advertiser accounts to export a mixed campaign report, incl
 
 ```bash
 curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/campaigns-detailed?start_date=2026-03-01&end_date=2026-03-22&campaign_name=summer&download=true' \
---header 'Authorization: Bearer XXXX' \
+--header 'x-app-id: XXXX' \
+--header 'x-api-key: YYYY' \
 --header 'Content-Type: application/json'
 ```
 

--- a/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
@@ -1,6 +1,6 @@
 # EXPORT ADVERTISER CAMPAIGNS DETAILED DATA - Reports Export Examples
 
-This endpoint allows advertiser accounts to export a mixed campaign report, including both regular campaigns and network campaign rows split by subpublisher when applicable. Data is returned in JSON format by default, but can be exported as XLSX by including the `download=true` parameter in the query string.
+This endpoint allows advertiser accounts to export a mixed campaign report, including both regular campaigns and subpublisher information for network campaigns. Data is returned in JSON format by default, but can be exported as XLSX by including the `download=true` parameter in the query string.
 
 ## Request
 

--- a/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
@@ -1,0 +1,88 @@
+# EXPORT ADVERTISER CAMPAIGNS DETAILED DATA - Reports Export Examples
+
+This endpoint allows advertiser accounts to export a mixed campaign report, including both regular campaigns and network campaign rows split by subpublisher when applicable. Data is returned in JSON format by default, but can be exported as XLSX by including the `download=true` parameter in the query string.
+
+## Request
+
+```bash
+curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/campaigns-detailed?start_date=2026-03-01&end_date=2026-03-22&campaign_name=summer&download=true' \
+--header 'Authorization: Bearer XXXX' \
+--header 'Content-Type: application/json'
+```
+
+## Query Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `start_date` | Yes | Start date for metrics in `YYYY-MM-DD` format. |
+| `end_date` | Yes | End date for metrics in `YYYY-MM-DD` format. |
+| `campaign_id` | No | Filters by campaign ID. |
+| `campaign_name` | No | Filters campaigns by name. |
+| `campaign_status` | No | Filters by campaign status. |
+| `publisher_id` | No | Filters by publisher ID. |
+| `publisher_name` | No | Filters by publisher name. |
+| `ad_type` | No | Filters by ad type. |
+| `ad_status` | No | Filters by ad status. |
+| `seller_id` | No | Filters by seller ID. |
+| `tag_id` | No | Filters by advertiser tag ID. |
+| `targeting_type` | No | Filters by targeting type. |
+| `sub_publisher_id` | No | Filters network rows by subpublisher ID. |
+| `sub_publisher_name` | No | Filters network rows by subpublisher name. |
+| `page` | No | Page number of the results. Default: `1`. |
+| `quantity` | No | Number of items per page. Default: `100`. When `download=true`, the BFF requests up to `20000` rows for XLSX generation. |
+| `count` | No | If `true`, returns pagination metadata. Default: `true`. |
+| `order_by` | No | Field for sorting results. Possible values include `advertiser_name`, `name`, `ad_type`, `status`, `sub_publisher_name`, `daily_budget`, `impressions`, `views`, `clicks`, `ctr`, `total_spent`, `conversions`, `conversion_rate`, `income`, `roas`, `created_at`, `start_at`. |
+| `order_direction` | No | Sort direction. Possible values: `asc` or `desc`. |
+| `download` | No | If `true`, returns an XLSX file instead of JSON. |
+
+## Notes
+
+- This route is intended for advertiser accounts.
+- In the BFF flow, `advertiser_id` is derived from the authenticated advertiser context.
+- For non white-label accounts, only non-private publisher rows are returned.
+- XLSX exports include `Subpublisher ID` and `Subpublisher` columns when network rows are present.
+
+## JSON Response Example
+
+```json
+{
+  "total": 1,
+  "pages": 1,
+  "currentPage": 1,
+  "data": [
+    {
+      "id": "campaign-id",
+      "advertiser_id": "advertiser-id",
+      "name": "Campaign Name",
+      "status": "partial_running",
+      "type": "on_site",
+      "publisher_id": "publisher-id",
+      "publisher_name": "Publisher Name",
+      "advertiser_name": "Advertiser Name",
+      "sub_publisher_id": "subpublisher-id",
+      "sub_publisher_name": "Subpublisher Name",
+      "active": true,
+      "daily_budget": "10000.00",
+      "consumed_budget": "1750.0000",
+      "pending": [],
+      "metrics": {
+        "clicks": 39,
+        "conversions": 4,
+        "total_conversions_items_quantity": 7,
+        "impressions": 7603,
+        "views": 51,
+        "conversion_rate": "10.26",
+        "ctr": ".51",
+        "roas": "2.64",
+        "adcost": "37.87",
+        "income": "25747.00",
+        "total_spent": "9750.00",
+        "ecpm": "3.3864",
+        "cpa": "2437.50",
+        "avg_cpc": "250.00",
+        "avg_cpm": "1282.39"
+      }
+    }
+  ]
+}
+```

--- a/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
@@ -5,7 +5,7 @@ This endpoint allows advertiser accounts to export a mixed campaign report, incl
 ## Request
 
 ```bash
-curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/campaigns-detailed?start_date=2026-03-01&end_date=2026-03-22&campaign_name=summer&download=true' \
+curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/campaigns-detailed?start_date=2026-03-01&end_date=2026-03-22&download=true' \
 --header 'x-app-id: XXXX' \
 --header 'x-api-key: YYYY' \
 --header 'Content-Type: application/json'
@@ -18,7 +18,6 @@ curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/camp
 | `start_date` | Yes | Start date for metrics in `YYYY-MM-DD` format. |
 | `end_date` | Yes | End date for metrics in `YYYY-MM-DD` format. |
 | `campaign_id` | No | Filters by campaign ID. |
-| `campaign_name` | No | Filters campaigns by name. |
 | `campaign_status` | No | Filters by campaign status. |
 | `publisher_id` | No | Filters by publisher ID. |
 | `publisher_name` | No | Filters by publisher name. |

--- a/pt/docs/6-exportacao-de-dados.md
+++ b/pt/docs/6-exportacao-de-dados.md
@@ -11,6 +11,7 @@ Além da exportação via S3, é possível extrair relatórios via API. As rotas
 *  `GET /report/network/publishers`: Publishers da rede (para contas do tipo Rede) [[Exemplo]](../../examples/EXPORT_NETWORK_PUBLISHERS_DATA.md)
 *  `GET /campaign/v2`: Relatório listagem de campanhas [[Exemplo]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Relatório detalhado da campanha [[Exemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
+*  `GET /report/advertisers/campaigns-detailed`: Relatório detalhado de campanhas mistas para contas de anunciante, incluindo linhas por subpublisher em campanhas de rede [[Exemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Relatório de anúncios [[Exemplo]](../../examples/EXPORT_ADS_DATA.md)
 
 ### 5.2. Exportação de Dados

--- a/pt/docs/6-exportacao-de-dados.md
+++ b/pt/docs/6-exportacao-de-dados.md
@@ -2,7 +2,7 @@
 
 A exportação de dados permite que você receba informações detalhadas sobre eventos e dados agregados de forma sistemática e periódica. A integração ocorre através de uma conexão S3, e os dados são entregues em formatos específicos para cada tipo de exportação.
 
-### 5.1. Relatórios
+### 6.1. Relatórios
 
 Além da exportação via S3, é possível extrair relatórios via API. As rotas retornam JSON por padrão, mas podem ser exportadas como arquivos XLSX ao incluir o parâmetro `download=true` na query.
 
@@ -11,10 +11,10 @@ Além da exportação via S3, é possível extrair relatórios via API. As rotas
 *  `GET /report/network/publishers`: Publishers da rede (para contas do tipo Rede) [[Exemplo]](../../examples/EXPORT_NETWORK_PUBLISHERS_DATA.md)
 *  `GET /campaign/v2`: Relatório listagem de campanhas [[Exemplo]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Relatório detalhado da campanha [[Exemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
-*  `GET /report/advertisers/campaigns-detailed`: Relatório detalhado de campanhas mistas para contas de anunciante, incluindo linhas por subpublisher em campanhas de rede [[Exemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
+*  `GET /report/advertisers/campaigns-detailed`: Relatório detalhado de campanhas mistas para contas de anunciante, incluindo informações de subpublisher em campanhas de rede [[Exemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Relatório de anúncios [[Exemplo]](../../examples/EXPORT_ADS_DATA.md)
 
-### 5.2. Exportação de Dados
+### 6.2. Exportação de Dados
 
 A integração sempre ocorrerá usando uma conexão S3 (ou compatível) que deverá ser disponibilizada pelo receptor dos dados. As credenciais devem ser passadas para o time da Newtail de forma segura.
 


### PR DESCRIPTION
## Summary
- add the new `/report/advertisers/campaigns-detailed` route to section 6 data export in English, Portuguese, and Spanish
- add a dedicated example page covering advertiser access, JSON/XLSX usage, filters, and subpublisher fields
- align the docs with the BFF behavior introduced for advertiser-only mixed campaign exports

## Test Plan
- [x] reviewed updated docs and links locally
- [x] verified the new example content matches the retail-media-api and BFF PR behavior