### PR TITLE
docs: add advertiser ads detailed export

### DIFF
--- a/en/docs/6-data-export.md
+++ b/en/docs/6-data-export.md
@@ -12,6 +12,7 @@ In addition to exporting via S3, it is possible to extract reports via the API. 
 *  `GET /campaign/v2`: Campaign listing report [[Example]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Detailed campaign report [[Example]](../../examples/EXPORT_CAMPAIGN_DATA.md)
 *  `GET /report/advertisers/campaigns-detailed`: Detailed mixed campaign report for advertiser accounts, including subpublisher information for network campaigns [[Example]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
+*  `GET /report/advertisers/ads-detailed`: Detailed ad report for advertiser accounts, including subpublisher breakdown for network campaigns [[Example]](../../examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Performance report for individual ads  [[Example]](../../examples/EXPORT_ADS_DATA.md)
 
 ### 6.2. Data Export

--- a/es/docs/6-exportacion-de-datos.md
+++ b/es/docs/6-exportacion-de-datos.md
@@ -12,6 +12,7 @@ Además de la exportación a través de S3, es posible extraer informes a travé
 *  `GET /campaign/v2`: Informe listado de campañas [[Ejemplo]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Informe detallado de la campaña [[Ejemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
 *  `GET /report/advertisers/campaigns-detailed`: Informe detallado de campañas mixtas para cuentas de anunciante, incluyendo información de subpublisher en campañas de red [[Ejemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
+*  `GET /report/advertisers/ads-detailed`: Informe detallado de anuncios para cuentas de anunciante, incluyendo el desglose por subpublisher en campañas de red [[Ejemplo]](../../examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Informe de anuncios individuales [[Ejemplo]](../../examples/EXPORT_ADS_DATA.md)
 
 ### 6.2. Exportación de Datos

--- a/examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md
@@ -1,6 +1,6 @@
 # EXPORT ADVERTISER ADS DETAILED DATA - Reports Export Examples
 
-This endpoint allows advertiser accounts to export a detailed ad report. It follows the ad-level view of `/ad/results/v2`, and for network campaigns it adds a subpublisher breakdown. Data is returned in JSON format by default, but can be exported as XLSX by including the `download=true` parameter in the query string.
+This endpoint allows advertiser accounts to export a detailed ad report. Adds a subpublisher breakdown for network campaigns. Data is returned in JSON format by default, but can be exported as XLSX by including the `download=true` parameter in the query string.
 
 ## Request
 

--- a/examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md
@@ -1,0 +1,95 @@
+# EXPORT ADVERTISER ADS DETAILED DATA - Reports Export Examples
+
+This endpoint allows advertiser accounts to export a detailed ad report. It follows the ad-level view of `/ad/results/v2`, and for network campaigns it adds a subpublisher breakdown. Data is returned in JSON format by default, but can be exported as XLSX by including the `download=true` parameter in the query string.
+
+## Request
+
+```bash
+curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/ads-detailed?start_date=2026-03-01&end_date=2026-03-22&campaign_id=campaign-id&show_inactive=true&download=true' \
+--header 'x-app-id: XXXX' \
+--header 'x-api-key: YYYY' \
+--header 'Content-Type: application/json'
+```
+
+## Query Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `start_date` | Yes | Start date for metrics in `YYYY-MM-DD` format. |
+| `end_date` | Yes | End date for metrics in `YYYY-MM-DD` format. |
+| `campaign_name` | No | Filters ads by campaign name. |
+| `campaign_id` | No | Filters ads by campaign ID. |
+| `publisher_id` | No | Filters ads by publisher ID. |
+| `advertiser_id` | No | Filters ads by advertiser ID. In the BFF flow, this value is derived from the authenticated advertiser context. |
+| `product_sku` | No | Filters ads by product SKU. |
+| `ad_status` | No | Filters ads by status. |
+| `ad_type` | No | Filters by ad type. |
+| `targeting_type` | No | Filters by targeting type. |
+| `tag_id` | No | Filters by advertiser tag ID. |
+| `sub_publisher_id` | No | Filters network rows by subpublisher ID. |
+| `sub_publisher_name` | No | Filters network rows by subpublisher name. |
+| `show_inactive` | No | If `true`, includes paused ads. Default: `false`. |
+| `hide_pending_rejected` | No | If `true`, excludes `pending_review` and `rejected` rows when `ad_status` is not provided. Default: `false`. |
+| `page` | No | Page number of the results. Default: `1`. |
+| `quantity` | No | Number of items per page. Default: `100`. When `download=true`, the BFF requests up to `20000` rows for XLSX generation. |
+| `count` | No | If `true`, returns pagination metadata. Default: `true`. |
+| `order_by` | No | Field for sorting results. Possible values include `ad_type`, `ad_status`, `impressions`, `conversion_rate`, `ctr`, `income`, `total_spent`, `roas`, `conversions`, `total_conversions_items_quantity`, `advertiser_name`, `campaign_name`, `clicks`, `adcost`, `created_at`, `sub_publisher_name`. |
+| `order_direction` | No | Sort direction. Possible values: `asc` or `desc`. |
+| `download` | No | If `true`, returns an XLSX file instead of JSON. |
+
+## Notes
+
+- This route is intended for advertiser accounts.
+- Non-network campaigns return one row per ad.
+- Network campaigns return one row per `ad + subpublisher`.
+- For non white-label accounts, only non-private publisher rows are returned.
+- XLSX exports include `Subpublisher ID` and `Subpublisher` columns when network rows are present.
+
+## JSON Response Example
+
+```json
+{
+  "total": 1,
+  "pages": 1,
+  "currentPage": 1,
+  "data": [
+    {
+      "id": "ad-id",
+      "campaign_id": "campaign-id",
+      "url": "https://example.com/product",
+      "status": "enabled",
+      "active": true,
+      "product_sku": "SKU-123",
+      "campaign_name": "Campaign Name",
+      "campaign_status": "running",
+      "ad_type": "product",
+      "publisher_id": "publisher-id",
+      "publisher_name": "Publisher Name",
+      "publisher_account_id": "publisher-account-id",
+      "advertiser_id": "advertiser-id",
+      "advertiser_name": "Advertiser Name",
+      "advertiser_account_id": "advertiser-account-id",
+      "sub_publisher_id": "subpublisher-id",
+      "sub_publisher_name": "Subpublisher Name",
+      "sub_publisher_account_id": "subpublisher-account-id",
+      "metrics": {
+        "clicks": "3",
+        "conversions": "1",
+        "total_conversions_items_quantity": "2",
+        "impressions": "10691",
+        "views": "0",
+        "conversion_rate": "33.33",
+        "ctr": "0.03",
+        "roas": "2.64",
+        "adcost": "37.87",
+        "income": "818.00",
+        "total_spent": "309.82000000",
+        "ecpm": "28.98",
+        "cpa": "309.82",
+        "avg_cpc": "103.27",
+        "avg_cpm": "28.98"
+      }
+    }
+  ]
+}
+```

--- a/pt/docs/6-exportacao-de-dados.md
+++ b/pt/docs/6-exportacao-de-dados.md
@@ -12,6 +12,7 @@ Além da exportação via S3, é possível extrair relatórios via API. As rotas
 *  `GET /campaign/v2`: Relatório listagem de campanhas [[Exemplo]](../../examples/EXPORT_CAMPAIGNS_LIST_DATA.md)
 *  `GET /campaign/:id`: Relatório detalhado da campanha [[Exemplo]](../../examples/EXPORT_CAMPAIGN_DATA.md)
 *  `GET /report/advertisers/campaigns-detailed`: Relatório detalhado de campanhas mistas para contas de anunciante, incluindo informações de subpublisher em campanhas de rede [[Exemplo]](../../examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md)
+*  `GET /report/advertisers/ads-detailed`: Relatório detalhado de anúncios para contas de anunciante, incluindo quebra por subpublisher em campanhas de rede [[Exemplo]](../../examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md)
 *  `GET /ad/results/v2`: Relatório de anúncios [[Exemplo]](../../examples/EXPORT_ADS_DATA.md)
 
 ### 6.2. Exportação de Dados


### PR DESCRIPTION
## Summary
- document the new GET /report/advertisers/ads-detailed export route
- add a dedicated example file with request, filters, notes, and JSON response
- link the new endpoint from the PT, EN, and ES data export docs