### PR TITLE
adding assisted metrics, roas breakdown and conversion rate view rm apis

### DIFF
--- a/examples/EXPORT_ADS_DATA.md
+++ b/examples/EXPORT_ADS_DATA.md
@@ -100,7 +100,7 @@ Important: Paused ads are excluded from the default response. To include paused 
         "impressions": "2900",
         "views": "2689",
         "conversion_rate": "1.89",
-        "conversion_rate_view": "0.70",
+        "conversion_rate_view": "0.04",
         "ctr": "1.83",
         "roas": "0.18",
         "adcost": "540.94",

--- a/examples/EXPORT_ADS_DATA.md
+++ b/examples/EXPORT_ADS_DATA.md
@@ -110,8 +110,6 @@ Important: Paused ads are excluded from the default response. To include paused 
         "cpa": "29000.00",
         "avg_cpc": "547.17",
         "avg_cpm": "10000.00",
-        "click_roas": "0.18",
-        "view_roas": "0.14",
         "assisted_income": "1200.00",
         "assisted_roas": "0.04",
         "assisted_orders": "1",
@@ -216,8 +214,6 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `cpa`                              | String | Cost per acquisition              |
 | `avg_cpc`                          | String | Average cost per click            |
 | `avg_cpm`                          | String | Average cost per mille            |
-| `click_roas`                       | String | Return on ad spend attributed to clicks |
-| `view_roas`                        | String | Return on ad spend attributed to views |
 | `assisted_income`                  | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
 | `assisted_roas`                    | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
 | `assisted_orders`                  | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |

--- a/examples/EXPORT_ADS_DATA.md
+++ b/examples/EXPORT_ADS_DATA.md
@@ -29,7 +29,7 @@ curl --location 'https://api-retail-media.newtail.com.br/ad/results/v2?start_dat
 | `page`                  | No       | Page number of the results. Default: `1`.                               |
 | `quantity`              | No       | Number of items per page. Default: `100`.                               |
 | `count`                 | No       | If `true`, returns the total number of available records. Default: `false`. |
-| `order_by`              | No       | Field for sorting results. Possible values: `ad_type`, `ad_status`, `impressions`, `conversion_rate`, `ctr`, `income`, `total_spent`, `roas`, `conversions`, `total_conversions_item_quantity`. |
+| `order_by`              | No       | Field for sorting results. Possible values: `ad_type`, `ad_status`, `impressions`, `conversion_rate`, `conversion_rate_view`, `ctr`, `income`, `total_spent`, `roas`, `conversions`, `total_conversions_item_quantity`. |
 | `order_direction`       | No       | Sort direction. Possible values: `asc` (ascending) or `desc` (descending). |
 | `download`              | No       | If `true`, returns an XLSX file buffer for download instead of JSON. |
 
@@ -100,6 +100,7 @@ Important: Paused ads are excluded from the default response. To include paused 
         "impressions": "2900",
         "views": "2689",
         "conversion_rate": "1.89",
+        "conversion_rate_view": "0.70",
         "ctr": "1.83",
         "roas": "0.18",
         "adcost": "540.94",
@@ -108,7 +109,14 @@ Important: Paused ads are excluded from the default response. To include paused 
         "ecpm": "1.85",
         "cpa": "29000.00",
         "avg_cpc": "547.17",
-        "avg_cpm": "10000.00"
+        "avg_cpm": "10000.00",
+        "click_roas": "0.18",
+        "view_roas": "0.14",
+        "assisted_income": "1200.00",
+        "assisted_roas": "0.04",
+        "assisted_orders": "1",
+        "assisted_items": "2",
+        "overall_roas": "0.22"
       }
     }
   ]
@@ -197,7 +205,8 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `total_conversions_items_quantity` | String | Total quantity of converted items |
 | `impressions`                      | String | Total number of impressions       |
 | `views`                            | String | Total number of views             |
-| `conversion_rate`                  | String | Conversion rate percentage        |
+| `conversion_rate`                  | String | Conversion rate percentage (clicks-based) |
+| `conversion_rate_view`             | String | Conversion rate percentage (views-based)  |
 | `ctr`                              | String | Click-through rate percentage     |
 | `roas`                             | String | Return on ad spend                |
 | `adcost`                           | String | Ad cost percentage                |
@@ -207,3 +216,10 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `cpa`                              | String | Cost per acquisition              |
 | `avg_cpc`                          | String | Average cost per click            |
 | `avg_cpm`                          | String | Average cost per mille            |
+| `click_roas`                       | String | Return on ad spend attributed to clicks |
+| `view_roas`                        | String | Return on ad spend attributed to views |
+| `assisted_income`                  | String/null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`                    | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders`                  | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`                   | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `overall_roas`                     | String | Combined return on ad spend from direct and assisted sales |

--- a/examples/EXPORT_ADS_DATA.md
+++ b/examples/EXPORT_ADS_DATA.md
@@ -218,8 +218,8 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `avg_cpm`                          | String | Average cost per mille            |
 | `click_roas`                       | String | Return on ad spend attributed to clicks |
 | `view_roas`                        | String | Return on ad spend attributed to views |
-| `assisted_income`                  | String/null | Assisted sales revenue (null when no assisted sales data is available) |
-| `assisted_roas`                    | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
-| `assisted_orders`                  | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
-| `assisted_items`                   | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `assisted_income`                  | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`                    | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders`                  | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`                   | String/Null | Number of items from assisted orders (null when no assisted sales data is available) |
 | `overall_roas`                     | String | Combined return on ad spend from direct and assisted sales |

--- a/examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_ADS_DETAILED_DATA.md
@@ -33,7 +33,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/ads-
 | `page` | No | Page number of the results. Default: `1`. |
 | `quantity` | No | Number of items per page. Default: `100`. When `download=true`, the BFF requests up to `20000` rows for XLSX generation. |
 | `count` | No | If `true`, returns pagination metadata. Default: `true`. |
-| `order_by` | No | Field for sorting results. Possible values include `ad_type`, `ad_status`, `impressions`, `conversion_rate`, `ctr`, `income`, `total_spent`, `roas`, `conversions`, `total_conversions_items_quantity`, `advertiser_name`, `campaign_name`, `clicks`, `adcost`, `created_at`, `sub_publisher_name`. |
+| `order_by` | No | Field for sorting results. Possible values include `ad_type`, `ad_status`, `impressions`, `conversion_rate`, `conversion_rate_view`, `ctr`, `income`, `total_spent`, `roas`, `conversions`, `total_conversions_items_quantity`, `advertiser_name`, `campaign_name`, `clicks`, `adcost`, `created_at`, `sub_publisher_name`. |
 | `order_direction` | No | Sort direction. Possible values: `asc` or `desc`. |
 | `download` | No | If `true`, returns an XLSX file instead of JSON. |
 
@@ -79,6 +79,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/ads-
         "impressions": "10691",
         "views": "0",
         "conversion_rate": "33.33",
+        "conversion_rate_view": "0.00",
         "ctr": "0.03",
         "roas": "2.64",
         "adcost": "37.87",

--- a/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
@@ -72,7 +72,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/camp
         "impressions": 7603,
         "views": 51,
         "conversion_rate": "10.26",
-        "conversion_rate_view": "3.92",
+        "conversion_rate_view": "7.84",
         "ctr": ".51",
         "roas": "2.64",
         "adcost": "37.87",

--- a/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
+++ b/examples/EXPORT_ADVERTISER_CAMPAIGNS_DETAILED_DATA.md
@@ -31,7 +31,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/camp
 | `page` | No | Page number of the results. Default: `1`. |
 | `quantity` | No | Number of items per page. Default: `100`. When `download=true`, the BFF requests up to `20000` rows for XLSX generation. |
 | `count` | No | If `true`, returns pagination metadata. Default: `true`. |
-| `order_by` | No | Field for sorting results. Possible values include `advertiser_name`, `name`, `ad_type`, `status`, `sub_publisher_name`, `daily_budget`, `impressions`, `views`, `clicks`, `ctr`, `total_spent`, `conversions`, `conversion_rate`, `income`, `roas`, `created_at`, `start_at`. |
+| `order_by` | No | Field for sorting results. Possible values include `advertiser_name`, `name`, `ad_type`, `status`, `sub_publisher_name`, `daily_budget`, `impressions`, `views`, `clicks`, `ctr`, `total_spent`, `conversions`, `conversion_rate`, `conversion_rate_view`, `income`, `roas`, `created_at`, `start_at`. |
 | `order_direction` | No | Sort direction. Possible values: `asc` or `desc`. |
 | `download` | No | If `true`, returns an XLSX file instead of JSON. |
 
@@ -72,6 +72,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/advertisers/camp
         "impressions": 7603,
         "views": 51,
         "conversion_rate": "10.26",
+        "conversion_rate_view": "3.92",
         "ctr": ".51",
         "roas": "2.64",
         "adcost": "37.87",

--- a/examples/EXPORT_ADVERTISER_DATA.md
+++ b/examples/EXPORT_ADVERTISER_DATA.md
@@ -50,6 +50,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/advertisers?s
         "clicks": "1237",
         "conversions": "0",
         "conversion_rate": "0.00",
+        "conversion_rate_view": "0.00",
         "total_conversions_items_quantity": "0",
         "ctr": "0.31",
         "income": "0.0000",
@@ -61,7 +62,14 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/advertisers?s
         "conversions_quantity": "0",
         "roas": "0.00",
         "adcost": "0.0",
-        "consumed_daily_budget": "4407.70"
+        "consumed_daily_budget": "4407.70",
+        "click_roas": "0.00",
+        "view_roas": "0.00",
+        "assisted_income": null,
+        "assisted_roas": null,
+        "assisted_orders": null,
+        "assisted_items": null,
+        "overall_roas": "0.00"
       },
       "account_logo": "https://cdn.newtail.com.br/accounts/4852asd4q-3b0a-11ef-b7a2-014ea2680b7e/assets/advertiser-logo.png",
       "account_theme": {
@@ -110,7 +118,8 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/advertisers?s
 | `views`                            | String | Total number of ad views          |
 | `clicks`                           | String | Total number of ad clicks         |
 | `conversions`                      | String | Total number of conversions       |
-| `conversion_rate`                  | String | Conversion rate percentage        |
+| `conversion_rate`                  | String | Conversion rate percentage (clicks-based) |
+| `conversion_rate_view`             | String | Conversion rate percentage (views-based)  |
 | `total_conversions_items_quantity` | String | Total quantity of converted items |
 | `ctr`                              | String | Click-through rate percentage     |
 | `income`                           | String | Total income generated            |
@@ -123,6 +132,13 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/advertisers?s
 | `roas`                             | String | Return on ad spend                |
 | `adcost`                           | String | Ad cost                           |
 | `consumed_daily_budget`            | String | Amount of daily budget consumed   |
+| `click_roas`                       | String | Return on ad spend attributed to clicks |
+| `view_roas`                        | String | Return on ad spend attributed to views |
+| `assisted_income`                  | String/null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`                    | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders`                  | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`                   | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `overall_roas`                     | String | Combined return on ad spend from direct and assisted sales |
 
 ### Account Theme Object Fields
 

--- a/examples/EXPORT_ADVERTISER_DATA.md
+++ b/examples/EXPORT_ADVERTISER_DATA.md
@@ -63,8 +63,6 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/advertisers?s
         "roas": "0.00",
         "adcost": "0.0",
         "consumed_daily_budget": "4407.70",
-        "click_roas": "0.00",
-        "view_roas": "0.00",
         "assisted_income": null,
         "assisted_roas": null,
         "assisted_orders": null,
@@ -132,8 +130,6 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/advertisers?s
 | `roas`                             | String | Return on ad spend                |
 | `adcost`                           | String | Ad cost                           |
 | `consumed_daily_budget`            | String | Amount of daily budget consumed   |
-| `click_roas`                       | String | Return on ad spend attributed to clicks |
-| `view_roas`                        | String | Return on ad spend attributed to views |
 | `assisted_income`                  | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
 | `assisted_roas`                    | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
 | `assisted_orders`                  | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |

--- a/examples/EXPORT_ADVERTISER_DATA.md
+++ b/examples/EXPORT_ADVERTISER_DATA.md
@@ -134,10 +134,10 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/advertisers?s
 | `consumed_daily_budget`            | String | Amount of daily budget consumed   |
 | `click_roas`                       | String | Return on ad spend attributed to clicks |
 | `view_roas`                        | String | Return on ad spend attributed to views |
-| `assisted_income`                  | String/null | Assisted sales revenue (null when no assisted sales data is available) |
-| `assisted_roas`                    | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
-| `assisted_orders`                  | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
-| `assisted_items`                   | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `assisted_income`                  | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`                    | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders`                  | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`                   | String/Null | Number of items from assisted orders (null when no assisted sales data is available) |
 | `overall_roas`                     | String | Combined return on ad spend from direct and assisted sales |
 
 ### Account Theme Object Fields

--- a/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
+++ b/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
@@ -90,8 +90,6 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/v2?start_date=
         "cpa": "2437.50",
         "avg_cpc": "250.00",
         "avg_cpm": "1282.39",
-        "click_roas": "2.31",
-        "view_roas": "0.33",
         "assisted_income": "3200.00",
         "assisted_roas": "0.33",
         "assisted_orders": "2",
@@ -183,8 +181,6 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `cpa`             | String | Cost per acquisition           |
 | `avg_cpc`         | String | Average cost per click         |
 | `avg_cpm`         | String | Average cost per mille         |
-| `click_roas`      | String | Return on ad spend attributed to clicks |
-| `view_roas`       | String | Return on ad spend attributed to views |
 | `assisted_income` | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
 | `assisted_roas`   | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
 | `assisted_orders` | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |

--- a/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
+++ b/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
@@ -24,7 +24,7 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/v2?start_date=
 | `page`            | No       | Page number of the results. Default: `1`.                               |
 | `quantity`        | No       | Number of items per page. Default: `100`.                               |
 | `count`           | No       | If `true`, returns the total number of available records. Default: `false`. |
-| `order_by`        | No       | Field for sorting results. Possible values: `name`, `impressions`, `clicks`, `ctr`, `conversions`, `conversion_rate`, `income`, `roas`, `created_at`, `start_at`, `daily_budget`, `ad_type`, `advertiser_name`, `status`. |
+| `order_by`        | No       | Field for sorting results. Possible values: `name`, `impressions`, `clicks`, `ctr`, `conversions`, `conversion_rate`, `conversion_rate_view`, `income`, `roas`, `created_at`, `start_at`, `daily_budget`, `ad_type`, `advertiser_name`, `status`. |
 | `order_direction` | No       | Sort direction. Possible values: `asc` (ascending) or `desc` (descending). |
 | `download`        | No       | If `true`, returns an XLSX file buffer for download instead of JSON. |
 
@@ -80,6 +80,7 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/v2?start_date=
         "impressions": 7603,
         "views": 51,
         "conversion_rate": "10.26",
+        "conversion_rate_view": "3.92",
         "ctr": ".51",
         "roas": "2.64",
         "adcost": "37.87",
@@ -88,7 +89,14 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/v2?start_date=
         "ecpm": "3.3864",
         "cpa": "2437.50",
         "avg_cpc": "250.00",
-        "avg_cpm": "1282.39"
+        "avg_cpm": "1282.39",
+        "click_roas": "2.31",
+        "view_roas": "0.33",
+        "assisted_income": "3200.00",
+        "assisted_roas": "0.33",
+        "assisted_orders": "2",
+        "assisted_items": "4",
+        "overall_roas": "2.97"
       }
     }
   ]
@@ -164,7 +172,8 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `conversions`     | Number | Total number of conversions    |
 | `impressions`     | Number | Total number of impressions    |
 | `views`           | Number | Total number of views          |
-| `conversion_rate` | String | Conversion rate percentage     |
+| `conversion_rate`      | String | Conversion rate percentage (clicks-based) |
+| `conversion_rate_view` | String | Conversion rate percentage (views-based)  |
 | `ctr`             | String | Click-through rate percentage  |
 | `roas`            | String | Return on ad spend             |
 | `adcost`          | String | Ad cost percentage             |
@@ -174,3 +183,10 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `cpa`             | String | Cost per acquisition           |
 | `avg_cpc`         | String | Average cost per click         |
 | `avg_cpm`         | String | Average cost per mille         |
+| `click_roas`      | String | Return on ad spend attributed to clicks |
+| `view_roas`       | String | Return on ad spend attributed to views |
+| `assisted_income` | String/null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`   | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders` | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`  | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `overall_roas`    | String | Combined return on ad spend from direct and assisted sales |

--- a/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
+++ b/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
@@ -80,7 +80,7 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/v2?start_date=
         "impressions": 7603,
         "views": 51,
         "conversion_rate": "10.26",
-        "conversion_rate_view": "3.92",
+        "conversion_rate_view": "7.84",
         "ctr": ".51",
         "roas": "2.64",
         "adcost": "37.87",

--- a/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
+++ b/examples/EXPORT_CAMPAIGNS_LIST_DATA.md
@@ -185,8 +185,8 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `avg_cpm`         | String | Average cost per mille         |
 | `click_roas`      | String | Return on ad spend attributed to clicks |
 | `view_roas`       | String | Return on ad spend attributed to views |
-| `assisted_income` | String/null | Assisted sales revenue (null when no assisted sales data is available) |
-| `assisted_roas`   | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
-| `assisted_orders` | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
-| `assisted_items`  | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `assisted_income` | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`   | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders` | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`  | String/Null | Number of items from assisted orders (null when no assisted sales data is available) |
 | `overall_roas`    | String | Combined return on ad spend from direct and assisted sales |

--- a/examples/EXPORT_CAMPAIGN_DATA.md
+++ b/examples/EXPORT_CAMPAIGN_DATA.md
@@ -68,6 +68,7 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/{CAMPAIGN_ID}?
     "impressions": 7603,
     "views": 51,
     "conversion_rate": "10.26",
+    "conversion_rate_view": "3.92",
     "ctr": ".51",
     "roas": "2.64",
     "adcost": "37.87",
@@ -76,7 +77,14 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/{CAMPAIGN_ID}?
     "ecpm": "3.3864",
     "cpa": "2437.50",
     "avg_cpc": "250.00",
-    "avg_cpm": "1282.39"
+    "avg_cpm": "1282.39",
+    "click_roas": "2.31",
+    "view_roas": "0.33",
+    "assisted_income": "3200.00",
+    "assisted_roas": "0.33",
+    "assisted_orders": "2",
+    "assisted_items": "4",
+    "overall_roas": "2.97"
   },
   "ads": [
     {
@@ -111,6 +119,7 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/{CAMPAIGN_ID}?
         "impressions": 7603,
         "views": 51,
         "conversion_rate": "10.26",
+        "conversion_rate_view": "3.92",
         "ctr": ".51",
         "roas": "2.64",
         "adcost": "37.87",
@@ -200,7 +209,8 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `conversions`     | Number | Total number of conversions    |
 | `impressions`     | Number | Total number of impressions    |
 | `views`           | Number | Total number of views          |
-| `conversion_rate` | String | Conversion rate percentage     |
+| `conversion_rate`      | String | Conversion rate percentage (clicks-based) |
+| `conversion_rate_view` | String | Conversion rate percentage (views-based)  |
 | `ctr`             | String | Click-through rate percentage  |
 | `roas`            | String | Return on ad spend             |
 | `adcost`          | String | Ad cost percentage             |
@@ -210,6 +220,13 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `cpa`             | String | Cost per acquisition           |
 | `avg_cpc`         | String | Average cost per click         |
 | `avg_cpm`         | String | Average cost per mille         |
+| `click_roas`      | String | Return on ad spend attributed to clicks |
+| `view_roas`       | String | Return on ad spend attributed to views |
+| `assisted_income` | String/null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`   | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders` | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`  | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `overall_roas`    | String | Combined return on ad spend from direct and assisted sales |
 
 ### Ad Object Fields
 
@@ -266,7 +283,8 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `conversions`     | Number | Total number of conversions    |
 | `impressions`     | Number | Total number of impressions    |
 | `views`           | Number | Total number of views          |
-| `conversion_rate` | String | Conversion rate percentage     |
+| `conversion_rate`      | String | Conversion rate percentage (clicks-based) |
+| `conversion_rate_view` | String | Conversion rate percentage (views-based)  |
 | `ctr`             | String | Click-through rate percentage  |
 | `roas`            | String | Return on ad spend             |
 | `adcost`          | String | Ad cost percentage             |

--- a/examples/EXPORT_CAMPAIGN_DATA.md
+++ b/examples/EXPORT_CAMPAIGN_DATA.md
@@ -222,10 +222,10 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `avg_cpm`         | String | Average cost per mille         |
 | `click_roas`      | String | Return on ad spend attributed to clicks |
 | `view_roas`       | String | Return on ad spend attributed to views |
-| `assisted_income` | String/null | Assisted sales revenue (null when no assisted sales data is available) |
-| `assisted_roas`   | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
-| `assisted_orders` | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
-| `assisted_items`  | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `assisted_income` | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`   | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders` | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`  | String/Null | Number of items from assisted orders (null when no assisted sales data is available) |
 | `overall_roas`    | String | Combined return on ad spend from direct and assisted sales |
 
 ### Ad Object Fields

--- a/examples/EXPORT_CAMPAIGN_DATA.md
+++ b/examples/EXPORT_CAMPAIGN_DATA.md
@@ -68,7 +68,7 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/{CAMPAIGN_ID}?
     "impressions": 7603,
     "views": 51,
     "conversion_rate": "10.26",
-    "conversion_rate_view": "3.92",
+    "conversion_rate_view": "7.84",
     "ctr": ".51",
     "roas": "2.64",
     "adcost": "37.87",

--- a/examples/EXPORT_CAMPAIGN_DATA.md
+++ b/examples/EXPORT_CAMPAIGN_DATA.md
@@ -78,8 +78,6 @@ curl --location 'https://api-retail-media.newtail.com.br/campaign/{CAMPAIGN_ID}?
     "cpa": "2437.50",
     "avg_cpc": "250.00",
     "avg_cpm": "1282.39",
-    "click_roas": "2.31",
-    "view_roas": "0.33",
     "assisted_income": "3200.00",
     "assisted_roas": "0.33",
     "assisted_orders": "2",
@@ -220,8 +218,6 @@ Important: This object is dynamic, depending on the type of campaign it may cont
 | `cpa`             | String | Cost per acquisition           |
 | `avg_cpc`         | String | Average cost per click         |
 | `avg_cpm`         | String | Average cost per mille         |
-| `click_roas`      | String | Return on ad spend attributed to clicks |
-| `view_roas`       | String | Return on ad spend attributed to views |
 | `assisted_income` | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
 | `assisted_roas`   | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
 | `assisted_orders` | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |

--- a/examples/EXPORT_NETWORK_PUBLISHERS_DATA.md
+++ b/examples/EXPORT_NETWORK_PUBLISHERS_DATA.md
@@ -24,7 +24,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/network/publishe
 | `page`            | No       | Page number of the results. Default: `1`.                                                                                                           |
 | `quantity`        | No       | Number of items per page. Default: `100`.                                                                                                           |
 | `count`           | No       | If `true`, returns the total number of available records. Default: `false`.                                                                         |
-| `order_by`        | No       | Field for sorting results. Possible values: `name`, `impressions`, `clicks`, `ctr`, `conversions`, `conversion_rate`, `income`, `roas`, `requests`. |
+| `order_by`        | No       | Field for sorting results. Possible values: `name`, `impressions`, `clicks`, `ctr`, `conversions`, `conversion_rate`, `conversion_rate_view`, `income`, `roas`, `requests`. |
 | `order_direction` | No       | Sort direction. Possible values: `asc` (ascending) or `desc` (descending).                                                                          |
 | `download`        | No       | If `true`, returns an XLSX file buffer for download instead of JSON.                                                                                |
 
@@ -46,7 +46,8 @@ curl --location 'https://api-retail-media.newtail.com.br/report/network/publishe
         "views": "0",
         "clicks": "0",
         "conversions": "0",
-        "conversion_rate": "0",
+        "conversion_rate": "0.00",
+        "conversion_rate_view": "0.00",
         "total_conversions_items_quantity": "0",
         "ctr": "0",
         "income": "0.00",
@@ -101,7 +102,8 @@ curl --location 'https://api-retail-media.newtail.com.br/report/network/publishe
 | `views`                            | String | Total number of ad views          |
 | `clicks`                           | String | Total number of ad clicks         |
 | `conversions`                      | String | Total number of conversions       |
-| `conversion_rate`                  | String | Conversion rate percentage        |
+| `conversion_rate`                  | String | Conversion rate percentage (clicks-based) |
+| `conversion_rate_view`             | String | Conversion rate percentage (views-based)  |
 | `total_conversions_items_quantity` | String | Total quantity of converted items |
 | `ctr`                              | String | Click-through rate percentage     |
 | `income`                           | String | Total income generated            |

--- a/examples/EXPORT_PUBLISHER_DATA.md
+++ b/examples/EXPORT_PUBLISHER_DATA.md
@@ -63,8 +63,6 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
           "conversions_quantity": "214",
           "roas": "433.92",
           "adcost": "0.23",
-          "click_roas": "412.65",
-          "view_roas": "21.27",
           "assisted_income": "45200.00",
           "assisted_roas": "33.73",
           "assisted_orders": "18",
@@ -129,8 +127,6 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
 | `conversions_quantity`             | String | Total quantity of converted items |
 | `roas`                             | String | Return on ad spend                |
 | `adcost`                           | String | Ad cost                           |
-| `click_roas`                       | String | Return on ad spend attributed to clicks |
-| `view_roas`                        | String | Return on ad spend attributed to views |
 | `assisted_income`                  | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
 | `assisted_roas`                    | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
 | `assisted_orders`                  | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |

--- a/examples/EXPORT_PUBLISHER_DATA.md
+++ b/examples/EXPORT_PUBLISHER_DATA.md
@@ -24,7 +24,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
 | `page`            | No          | Page number of results. Default: `1`.                                       |
 | `quantity`        | No          | Number of items per page. Default: `100`. |
 | `count`           | No          | If `true`, returns the total number of records available. Default: `false`. |
-| `order_by`        | No          | Field for sorting results. Possible values: `name`, `balance`, `total_daily_budget`, `total_campaigns`, `impressions`, `clicks`, `ctr`, `total_spent`, `conversions`, `conversion_rate`, `income`, `roas`. |
+| `order_by`        | No          | Field for sorting results. Possible values: `name`, `balance`, `total_daily_budget`, `total_campaigns`, `impressions`, `clicks`, `ctr`, `total_spent`, `conversions`, `conversion_rate`, `conversion_rate_view`, `income`, `roas`. |
 | `order_direction` | No          | Sort direction. Possible values: `asc` (ascending) or `desc` (descending).  |
 | `download`        | No          | If `true`, returns an XLSX file buffer for download instead of JSON.        |
 
@@ -51,6 +51,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
           "clicks": "4954",
           "conversions": "214",
           "conversion_rate": "4.32",
+          "conversion_rate_view": "1.87",
           "total_conversions_items_quantity": "214",
           "ctr": "0.09",
           "income": "581620.1500",
@@ -61,7 +62,14 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
           "avg_cpm": "0.25",
           "conversions_quantity": "214",
           "roas": "433.92",
-          "adcost": "0.23"
+          "adcost": "0.23",
+          "click_roas": "412.65",
+          "view_roas": "21.27",
+          "assisted_income": "45200.00",
+          "assisted_roas": "33.73",
+          "assisted_orders": "18",
+          "assisted_items": "24",
+          "overall_roas": "467.65"
       },
       "account_logo": "https://cdn.newtail.com.br/accounts/4852asd4q-3b0a-11ef-b7a2-014ea2680b7e/assets/publisher-logo.png",
       "account_theme": {
@@ -108,7 +116,8 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
 | `views`                            | String | Total number of ad views          |
 | `clicks`                           | String | Total number of ad clicks         |
 | `conversions`                      | String | Total number of conversions       |
-| `conversion_rate`                  | String | Conversion rate percentage        |
+| `conversion_rate`                  | String | Conversion rate percentage (clicks-based) |
+| `conversion_rate_view`             | String | Conversion rate percentage (views-based)  |
 | `total_conversions_items_quantity` | String | Total quantity of converted items |
 | `ctr`                              | String | Click-through rate percentage     |
 | `income`                           | String | Total income generated            |
@@ -120,6 +129,13 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
 | `conversions_quantity`             | String | Total quantity of converted items |
 | `roas`                             | String | Return on ad spend                |
 | `adcost`                           | String | Ad cost                           |
+| `click_roas`                       | String | Return on ad spend attributed to clicks |
+| `view_roas`                        | String | Return on ad spend attributed to views |
+| `assisted_income`                  | String/null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`                    | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders`                  | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`                   | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `overall_roas`                     | String | Combined return on ad spend from direct and assisted sales |
 
 ### Account Theme Object Fields
 

--- a/examples/EXPORT_PUBLISHER_DATA.md
+++ b/examples/EXPORT_PUBLISHER_DATA.md
@@ -131,10 +131,10 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
 | `adcost`                           | String | Ad cost                           |
 | `click_roas`                       | String | Return on ad spend attributed to clicks |
 | `view_roas`                        | String | Return on ad spend attributed to views |
-| `assisted_income`                  | String/null | Assisted sales revenue (null when no assisted sales data is available) |
-| `assisted_roas`                    | String/null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
-| `assisted_orders`                  | String/null | Number of orders assisted by the ad (null when no assisted sales data is available) |
-| `assisted_items`                   | String/null | Number of items from assisted orders (null when no assisted sales data is available) |
+| `assisted_income`                  | String/Null | Assisted sales revenue (null when no assisted sales data is available) |
+| `assisted_roas`                    | String/Null | Return on ad spend from assisted orders (null when no assisted sales data is available) |
+| `assisted_orders`                  | String/Null | Number of orders assisted by the ad (null when no assisted sales data is available) |
+| `assisted_items`                   | String/Null | Number of items from assisted orders (null when no assisted sales data is available) |
 | `overall_roas`                     | String | Combined return on ad spend from direct and assisted sales |
 
 ### Account Theme Object Fields

--- a/examples/EXPORT_PUBLISHER_DATA.md
+++ b/examples/EXPORT_PUBLISHER_DATA.md
@@ -51,7 +51,7 @@ curl --location 'https://api-retail-media.newtail.com.br/report/v2/publishers?st
           "clicks": "4954",
           "conversions": "214",
           "conversion_rate": "4.32",
-          "conversion_rate_view": "1.87",
+          "conversion_rate_view": "0.00",
           "total_conversions_items_quantity": "214",
           "ctr": "0.09",
           "income": "581620.1500",


### PR DESCRIPTION
## Adding assisted metrics and conversion rate view

This PR adds the new assisted sales metrics and conversion rate per view.

Updating the responses and descriptions of the data export endpoints.